### PR TITLE
Remove unexistent exported methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import cookies, { getPolicyCookie, addPolicyCookie, removePolicyCookie } from './src/cookies';
+import cookies from './src/cookies';
 import debounce from './src/debounce';
 import events from './src/events';
 import forEach from './src/forEach';
@@ -9,9 +9,6 @@ import touchable from './src/touchable';
 
 const purejs = {
   cookies,
-  getPolicyCookie,
-  addPolicyCookie,
-  removePolicyCookie,
   debounce,
   events,
   forEach,
@@ -23,9 +20,6 @@ const purejs = {
 
 export {
   cookies,
-  getPolicyCookie,
-  addPolicyCookie,
-  removePolicyCookie,
   debounce,
   events,
   forEach,


### PR DESCRIPTION
Me parece que se han colado estos metodos en un refactor.

Fueron eliminados aquí: https://github.com/Runroom/purejs/commit/fc3c5b7ca87b36cdfc256f8d7b7c2cbd59f3ab07

Pero no de este archivo.