### PR TITLE
Hotfix/docs

### DIFF
--- a/doc/anchorTo.md
+++ b/doc/anchorTo.md
@@ -7,7 +7,7 @@ import anchorTo from '@runroom/purejs/lib/anchorTo';
 
 // Usage
 anchorTo({ element: 300 });
-//or
+// or
 anchorTo({ element: '#section' })
 ```
 
@@ -15,5 +15,5 @@ It will anchor to a certain value or element in th window. If a class or id is p
 
 | Parameters | Description                                    |
 | ---------- | :--------------------------------------------- |
-| element    | `{integer|string}` Number, element class or id |
+| element    | `{integer\|string}` Number, element class or id |
 | offset     | `{integer}` Offset of the scroll. Default is 0 |

--- a/doc/animateTo.md
+++ b/doc/animateTo.md
@@ -7,7 +7,7 @@ import animateTo from '@runroom/purejs/lib/animateTo';
 
 // Usage
 animateTo({ element: 300 });
-//or
+// or
 animateTo({ element: '#section', speed: 500 })
 ```
 
@@ -15,6 +15,6 @@ It will anchor to a certain value or element in the window. If a class or id is 
 
 | Setting | Description                                        |
 | ------- | :------------------------------------------------- |
-| element | `{integer|string}` Number, element class or id     |
+| element | `{integer\|string}` Number, element class or id     |
 | speed   | `{integer}` Speed of the animation. Default is 500 |
 | offset  | `{integer}` Offset of the scroll. Default is 0     |


### PR DESCRIPTION
On 2 markdown files:

* Escapes pipe character inside table
* Adds space after comment slashes